### PR TITLE
Fix licensing text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,3 @@
-This code is released under the [GPL] version 4
-
-OneNote Md Exporter embeds PanDoc document covertor
-Copyright (C) 2006-2021 John MacFarlane <jgm at berkeley dot edu>
-
-
-----------------------------------------------------------------------
-
                    GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Comparison between OneNote Md Exporter and ENEX Export methods. Choose the one b
 3. [For Joplin Users] Import
    * From Joplin windows app, File > Import > "RAW - Joplin Export Directory"
 
-In case of error during export very that :
+In case of error during export very that:
 * OneNote and Word are correctly installed
 * OneNote is open before running the tool
 * Both OneNote and the tool are NOT run as administrator
@@ -93,15 +93,24 @@ You can contribute by adding translation in your language. You just need to :
 * Export page as DocX and translate them in Md (GitHub Flavor) using PanDoc
 * Apply some post-processing based on Regex to correct formatting issues
 * Extensible : new export format can be easily added to the code
-* Begining of integration test (need to be completed)
+* Beginning of integration test (need to be completed)
 
 # Licence
 
 Released under the GPL, version 3.
 
-This software carries no warranty of any kind. Some data can be lost during the export process. I recommand to review your notes after export and keep a backup of your OneNote notebooks just in case.
+This software carries no warranty of any kind. Some data can be lost during the export process. I recommend to review your notes after export and keep a backup of your OneNote notebooks just in case.
 
-OneNote Md Exporter embeds PanDoc, a document convertor software, 
+# Pandoc licence terms
+
+OneNote Md Exporter uses PanDoc universal markup converter.
+
+Pandoc is available at https://github.com/jgm/pandoc
+
+Pandoc is released under the following licence terms, full licence details can be found on the pandoc site.
+```
+© 2006-2021 John MacFarlane (jgm@berkeley.edu). Released under the GPL, version 2 or greater. This software carries no warranty of any kind.
+```
 
 #  Contributions
 


### PR DESCRIPTION
This would be something you would want to check before merging however I think this is what the licence was intended to be.  

Correction to licence file for GPLv3 (you had written GPL version 4 which does not exist)
Added terms for Pandoc to readme and link to code site instead of in the Licence file. For the releases you may just want to include the license from the pandoc github as is to go along with the compiled binary of pandoc.exe (which i see you have already done).
Spelling/grammar fixes to the readme. 