### PR TITLE
Fix incorrect character representations in OneNote API

### DIFF
--- a/src/OneNoteMdExporter/Helpers/OneNoteExtensions.cs
+++ b/src/OneNoteMdExporter/Helpers/OneNoteExtensions.cs
@@ -109,6 +109,13 @@ namespace alxnbl.OneNoteMdExporter.Helpers
             foreach (XElement xmlChildSection in xmlChildSections)
             {
                 Section childSection = xmlChildSection.GetSection(node);
+
+                // OneNote API incorrectly returns "^M" for "+" in section titles XML.
+                childSection.Title = childSection.Title.Replace("^M", "+");
+
+                // OneNote API incorrectly returns "^J" for "," in section titles XML.
+                childSection.Title = childSection.Title.Replace("^J", ",");
+
                 node.Childs.Add(childSection);
 
                 if (childSection.IsSectionGroup)


### PR DESCRIPTION
The code changes introduce a fix for incorrect character representations in section titles returned by the OneNote API. Specifically, the changes replace instances of "^M" with "+" and "^J" with "," in the section titles.