### PR TITLE
Fix: PageTitleMaxLength setting is ignored and page title is truncated if longer than 50 chars (closes #117)

### DIFF
--- a/src/OneNoteMdExporter/Helpers/OneNoteExtensions.cs
+++ b/src/OneNoteMdExporter/Helpers/OneNoteExtensions.cs
@@ -70,7 +70,7 @@ namespace alxnbl.OneNoteMdExporter.Helpers
 
             // Limit title max size, especially for notes with no title where the 1st paragraph is returned as a title
             if (title.Length > AppSettings.PageTitleMaxLength)
-                title = new string(title.Take(50).ToArray()) + "...";
+                title = new string(title.Take(AppSettings.PageTitleMaxLength).ToArray()) + "...";
 
             var page = new Page(parentSection)
             {

--- a/src/OneNoteMdExporter/appSettings.json
+++ b/src/OneNoteMdExporter/appSettings.json
@@ -10,7 +10,7 @@
   "ResourceFolderName": "resources",
 
   /* Maximum number of characters of a page title. Above this limit, title is contracted. */
-  "PageTitleMaxLength": 50,
+  "PageTitleMaxLength": 350,
 
   /****************************
     Markdown format general settings

--- a/src/OneNoteMdExporter/appSettings.json
+++ b/src/OneNoteMdExporter/appSettings.json
@@ -10,7 +10,7 @@
   "ResourceFolderName": "resources",
 
   /* Maximum number of characters of a page title. Above this limit, title is contracted. */
-  "PageTitleMaxLength": 350,
+  "PageTitleMaxLength": 50,
 
   /****************************
     Markdown format general settings


### PR DESCRIPTION
closes #117 