### PR TITLE
Fixed OneNote header regex

### DIFF
--- a/src/OneNoteMdExporter/Services/ConverterService.cs
+++ b/src/OneNoteMdExporter/Services/ConverterService.cs
@@ -133,7 +133,7 @@ namespace alxnbl.OneNoteMdExporter.Services
 
         private static string RemoveOneNoteHeader(string pageTxt)
         {
-            var pageTxtModified = Regex.Replace(pageTxt, @"^.+(\n|\r|\r\n){1,2}.+(\n|\r|\r\n){1,2}\d{2}:\d{2}\s+", "");
+            var pageTxtModified = Regex.Replace(pageTxt, @"^(\n|\r)*.+(\n|\r)+.+(\n|\r)+\d{1,2}:\d{2}\s(AM|PM)(\n|\r)+", "");
 
             return pageTxtModified;
         }


### PR DESCRIPTION
In my exports, my content usually has headers like this:
```
Title\r\nWednesday, November 08, 2017\r\n7:45 AM\r\n\r\nBody
Title\r\nWednesday, November 08, 2017\r\n12:45 PM\r\n\r\nBody
\r\n\r\nTitle\r\nWednesday, November 08, 2017\r\n12:45 PM\r\n\r\nBody
```
Note the..
- potential newlines at the beginning
- 1 or 2 digit hour
- AM or PM

This resulted in most of my pages not having the header stripped. This updated regex can handle these situations. Let me know any questions.