### PR TITLE
ConvertOnenoteTags: Fix Linq exception when iterating over tags

### DIFF
--- a/src/OneNoteMdExporter/Services/Export/ExportServiceBase.cs
+++ b/src/OneNoteMdExporter/Services/Export/ExportServiceBase.cs
@@ -459,6 +459,12 @@ namespace alxnbl.OneNoteMdExporter.Services.Export
             // Find occurances and replace
             foreach (var tagElement in xmlPageContent.Descendants(ns + "Tag"))
             {
+                if (tagElement.Parent == null || tagElement.Parent.Descendants(ns + "T").Count() == 0)
+                {
+                    // No known text element associated to the tag, we skip it
+                    continue;
+                }
+
                 // Get the corresponding text element
                 XElement textElement = tagElement.Parent.Descendants(ns + "T").First() as XElement;
                 if (textElement.FirstNode is not XCData)


### PR DESCRIPTION
Seen with one of my OneNote pages:

```
[12:49:34 DBG] Sequence contains no elements
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at alxnbl.OneNoteMdExporter.Services.Export.ExportServiceBase.ConvertOnenoteTags(XElement xmlPageContent, XNamespace ns) in onenote-md-exporter\src\OneNoteMdExporter\Services\Export\ExportServiceBase.cs:line 469
   at alxnbl.OneNoteMdExporter.Services.Export.ExportServiceBase.PageXmlPreProcessing(XElement xmlPageContent) in onenote-md-exporter\src\OneNoteMdExporter\Services\Export\ExportServiceBase.cs:line 270
   at alxnbl.OneNoteMdExporter.Services.Export.ExportServiceBase.ExportPage(Page page, Boolean retry) in onenote-md-exporter\src\OneNoteMdExporter\Services\Export\ExportServiceBase.cs:line 116
```

Fixed by adding a `null` check for the `tagElement.Parent` and descendents.